### PR TITLE
Initial Docs for Scheduler

### DIFF
--- a/docs-book/master_middleman/source/index.html.md.erb
+++ b/docs-book/master_middleman/source/index.html.md.erb
@@ -7,7 +7,7 @@
       <li class="panel span3">
         <a class="configure" href="myservice/index.html" id="service-docs">
           <div class="prodname">
-            Your Service for PCF<br />(Create your docs here)
+            Scheduler <br/> for PCF
           </div>
         </a>
       </li>

--- a/docs-book/master_middleman/source/subnavs/myservice_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/myservice_subnav.erb
@@ -5,19 +5,19 @@
   <div class="nav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/myservice/index.html">YOUR-PRODUCT-NAME</a>
+        <a id='home-nav-link' href="/myservice/index.html">Scheduler for PCF</a>
       </li>
 
       <li>
-        <a href="/myservice/installing.html">Installing and Configuring YOUR-PRODUCT-NAME</a>
+        <a href="/myservice/installing.html">Installing and Configuring Scheduler for PCF</a>
       </li>
 
       <li>
-        <a href="/myservice/using.html">Using YOUR-PRODUCT-NAME</a>
+        <a href="/myservice/using.html">Using Scheduler for PCF</a>
       </li>
 
       <li>
-        <a href="/myservice/release-notes.html">YOUR-PRODUCT-NAME Release Notes</a>
+        <a href="/myservice/release-notes.html">Scheduler for PCF Release Notes</a>
       </li>
       
     </ul>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,58 +1,64 @@
 ---
-title: YOUR-PRODUCT-NAME
-owner: Partners
+title: Scheduler for PCF (Beta)
+owner: Pivotal
 ---
 
-**This topic should begin with a brief description of your product. See below for an example.**
+<style>
+    .note.warning {
+        background-color: #fdd;
+        border-color: #fbb
+    }
+    .note.warning:before {
+        color: #f99;
+     }
+</style>
 
-This documentation describes the Redis Labs Enterprise Cluster (RLEC) Service Broker for Pivotal Cloud Foundry (PCF). 
-The RLEC Service Broker registers a service broker on PCF and exposes its service plans on the Marketplace. 
-Developers can provision Redis databases by creating instances of the service plans using Apps Manager or the cf CLI.
+<p class="note warning">
+<strong>IMPORTANT: </strong> 
+The Scheduler for PCF tile is currently in Beta and is meant for evaluation and test purposes only. Do not use this product in a PCF production environment.
+</p>
+
+This documentation describes the Scheduler for PCF Service Broker for Pivotal Cloud Foundry (PCF). 
+The Scheduler for PCF Service Broker is exposed as a service in the PCF Marketplace.  Developers use the service to create and schedule jobs by creating and binding to instances of the standard service plan using Apps Manager or the cf CLI.
 
 ## <a id='overview'></a>Overview
 
-**The overview should provide a description of the product's key features.**
+Scheduler for PCF includes the following key feature:
 
-YOUR-PRODUCT-NAME includes the following key features:
-
-* Feature one.
-* Feature two.
-* Feature three.
+* Create jobs to execute tasks (Diego Tasks).
+* Execute jobs on an ad-hoc basis.
+* Schedule jobs to execute on a recurring basis.
+* View job status and history.
 
 ## <a id="snapshot"></a>Product Snapshot
 
 <dl>
-<dt>YOUR-PRODUCT-NAME details:</dt>
-<dd><strong>Version</strong>: vYOUR-VERSION-NUMBER </dd>
-<dd><strong>Release date</strong>: YOUR-RELEASE-DATE (Ex: August 1, 2016)</dd>
-<dd><strong>Software component version</strong>: vYOUR-SOFTWARE-COMPONENT-VERSION-NUMBER</dd>
-<dd><strong>Compatible Ops Manager version(s)</strong>: vYOUR-COMPATIBLE-OPS-MAN-VERSION (Ex. v1.6.x, v1.7.x)</dd>
-<dd><strong>Compatible Elastic Runtime version(s)</strong>: vYOUR-COMPATIBLE-ELASTIC-RUNTIME-VERSION (Ex. v1.4.x, v1.5.x, v1.6.x)</dd>
-<dd><strong>vSphere support?</strong> Yes-OR-No</dd>
-<dd><strong>OpenStack support?</strong> Yes-OR-No</dd>
-<dd><strong>AWS support?</strong> Yes-OR-No</dd>
+<dt>Scheduler for PCF details:</dt>
+<dd><strong>Version</strong>: v1.0 </dd>
+<dd><strong>Release date</strong>: April 14, 2017</dd>
+<dd><strong>Software component version</strong>: v1.0.3</dd>
+<dd><strong>Compatible Ops Manager version(s)</strong>: v1.9.x, v1.10.x</dd>
+<dd><strong>Compatible Elastic Runtime version(s)</strong>: v1.9.x, v1.10.x</dd>
+<dd><strong>vSphere support?</strong> Yes</dd>
+<dd><strong>OpenStack support?</strong> Yes</dd>
+<dd><strong>AWS support?</strong> Yes</dd>
 </dl>
 
 ## <a id="reqs"></a>Requirements
 
-**Provide any general or specific requirements, prerequisites, or dependencies here. 
-A general requirement might be something like, "An AppDynamics account." 
-A specific requirement might be something like, "Packaging Dependencies for Offline Buildpacks."**
+Scheduler for PCF has the following requirements:
 
-YOUR-PRODUCT-NAME has the following requirements:
-
-+ PREREQUISITE-1
-
-+ PREREQUISITE-2
++ ERT 1.9 or 1.10
++ MySQL for PCF 1.8 or 1.9
 
 ## <a id="limitations"></a>Limitations
 
-**List any known limitations.**
++ None
 
 ## <a id="feedback"></a>Feedback
 
 Please provide any bugs, feature requests, or questions to the 
-[Pivotal Cloud Foundry Feedback](mailto:pivotal-cf-feedback@pivotal.io) list or send an email to YOUR-SUPPORT-EMAIL.
+[Pivotal Cloud Foundry Feedback](mailto:pivotal-cf-feedback@pivotal.io) list or send an email to [Support](mailto:support@pivotal.io).
 
 ## <a id='license'></a>License
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -1,28 +1,59 @@
 ---
-title: Installing and Configuring YOUR-PRODUCT-NAME
-owner: Partners
+title: Installing and Configuring Scheduler for PCF
+owner: Pivotal
 ---
 
-This topic describes how to install and configure YOUR-PRODUCT-NAME.
+<style>
+    .note.warning {
+        background-color: #fdd;
+        border-color: #fbb
+    }
+    .note.warning:before {
+        color: #f99;
+     }
+</style>
 
-##<a id='install'></a> Install and Configure YOUR-PRODUCT-NAME
+<p class="note warning">
+<strong>IMPORTANT: </strong> 
+The Scheduler for PCF tile is currently in Beta and is meant for evaluation and test purposes only. Do not use this product in a PCF production environment.
+</p>
+This topic describes how to install and configure Scheduler for PCF.
+
+##<a id='prereq'></a> Prerequisite for Scheduler for PCF
+
+1. If one does not exist, Create a `1gb` service plan in the MySQL for PCF tile.
+ 
+  1. Click the **MySQL for PCF** tile. 
+ 
+  1. Click **Service Plans** section.
+ 
+  1. Click **Add**.
+ 
+  1. Enter `1gb` for the **Service Plan Name**.
+ 
+  1. Enter a **Description**.
+ 
+  1. Enter `1000` for a **Storage Quota**.
+ 
+  1. Enter `40` for **Concurrent Connections Quota**.
+ 
+  1. Click **Save**.  
+ 
+  1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to create the 1gb service plan in the MySQL for PCF service.
+
+##<a id='install'></a> Install and Configure Scheduler for PCF
 
 1. Download the product file from Pivotal Network.
 
 1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file. 
 
-1. Under the **Import a Product** button, click **+** next to the version number of YOUR-PRODUCT-NAME. 
+1. Under the **Import a Product** button, click **+** next to the version number of Scheduler for PCF. 
 This adds the tile to your staging area.
 
-1. Click the newly added **YOUR-PRODUCT-NAME** tile.
+1. Click the newly added **Scheduler for PCF** tile.
 
-1. **This portion of the procedure should tell the users how to configure the newly added tile by
-walking them through the sections. Which fields should they fill out? What are the different
-checkboxes? Include relevant screenshots here.** 
+1. Make sure all configuration of network and stemcells is complete.
 
 1. Click **Save**.
 
-1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to install YOUR-PRODUCT-NAME tile.
-
-**If needed, include additional configuration information below. For example, maybe there are
-configuration options not required for installation but which could be useful for certain users.**
+1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to install Scheduler for PCF tile.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,19 +1,38 @@
 ---
-title: YOUR-PRODUCT-NAME Release Notes
+title: Scheduler for PCF Release Notes
 owner: Partners
 ---
 
-**This topic should include the Release Notes for your product. For examples, see the 
-[GCP Service Broker Release Notes](http://docs.pivotal.io/gcp-sb/release-notes.html) or the 
-[ISS Knowtify Search Analytics Release Notes](http://docs.pivotal.io/knowtify/release.html).
-When you release a new version, add new release notes to this file, keeping the older notes below.**
+<style>
+    .note.warning {
+        background-color: #fdd;
+        border-color: #fbb
+    }
+    .note.warning:before {
+        color: #f99;
+     }
+</style>
 
-### vCURRENT-VERSION-NUMBER (Ex. v1.0.1)
+<p class="note warning">
+<strong>IMPORTANT: </strong> 
+The Scheduler for PCF tile is currently in Beta and is meant for evaluation and test purposes only. Do not use this product in a PCF production environment.
+</p>
 
-**Release Date:** RELEASE-DATE (Ex. August 1, 2016)
+This topic contains release notes for the Concourse for Pivotal Cloud Foundry (PCF) tile.
 
-Features included in this release:
+### v1.0.2
 
-* Feature one.
-* Feature two.
-* Feature three.
+**Release Date:** April 19, 2017
+
+###Features included in this release:
+
+* Create Jobs.
+* Run Jobs.
+* Schedule Jobs.
+* List Job History.
+
+###Known issues in this release:
+
+* Operators must create (if one doesn't already exist) a p-msql service plan named "1gb" with at least 100 MB of disk space.
+* Only a "standard" service plan exists that allows scheduling of as many tasks as desired and at any scheduled interval desired.
+

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -35,4 +35,5 @@ This topic contains release notes for the Concourse for Pivotal Cloud Foundry (P
 
 * Operators must create (if one doesn't already exist) a p-msql service plan named "1gb" with at least 100 MB of disk space.
 * Only a "standard" service plan exists that allows scheduling of as many tasks as desired and at any scheduled interval desired.
+* Some buildpacks (python and ruby) do not properly create a `web` process_type command by default.  These buildpacks require that you take special considerations or they will no longer be accessible via the CF CLI.
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,15 +1,267 @@
 ---
-title: Using YOUR-PRODUCT-NAME
+title: Using Scheduler for PCF
 owner: Partners
 ---
 
-This topic describes how to use YOUR-PRODUCT-NAME.
+<style>
+    .note.warning {
+        background-color: #fdd;
+        border-color: #fbb
+    }
+    .note.warning:before {
+        color: #f99;
+     }
+</style>
 
-##<a id='using'></a> Using YOUR-PRODUCT-NAME
+<p class="note warning">
+<strong>IMPORTANT: </strong> 
+The Scheduler for PCF tile is currently in Beta and is meant for evaluation and test purposes only. Do not use this product in a PCF production environment.
+</p>
 
-**This topic should include any instructions for how to use the service or dashboard created by the tile. 
-Give procedures for how to perform the different functions offered by your product and provide screenshots where necessary.** 
+This topic provides instructions for using the Schedule for PCF service with their Pivotal Cloud Foundry (PCF) apps. Scheduler for PCF enables ad-hoc and scheduled execution of tasks on PCF.
 
-**You can also use this section to include information about Architecture and Troubleshooting for known errors. 
-If you include a Troubleshooting section, follow the Symptom/Explanation format used in the 
-[Okta Troubleshooting](http://docs.pivotal.io/p-identity/okta/troubleshooting.html) topic**.
+These procedures use the Cloud Foundry Command-Line Interface (cf CLI). You can also use [Apps Manager](http://docs.pivotal.io/pivotalcf/console/dev-console.html) to perform the same tasks using a graphical UI.
+
+For general information, see [Managing Service Instances with the cf CLI](http://docs.pivotal.io/devguide/services/managing-services.html). 
+
+## <a id="prereqs"></a>Prerequisites
+
+* A PCF installation with [Scheduler for PCF](https://network.pivotal.io/products/scheduler-for-pcf) installed and listed in the [Marketplace](http://docs.pivotal.io/devguide/services/#instances)
+* A [Space Developer](http://docs.pivotal.io/pivotalcf/concepts/roles.html#roles) account on the PCF installation
+
+#### To use Scheduler for PCF CLI Plugin, you need:
+* A local machine with the following installed:
+   - a browser
+   - a shell
+   - the [Cloud Foundry Command-Line Interface](http://docs.pivotal.io/pivotalcf/cf-cli/install-go-cli.html) (cf CLI)
+   - the [Scheduler for PCF Command-Line Interface Plugin](http://docs.pivotal.io/pivotalcf/scheduler-for-pcf/install-cli.html) 
+* To [log into](http://docs.pivotal.io/pivotalcf/cf-cli/getting-started.html#login) the org and space containing your app
+
+#### To use Scheduler for PCF API, you need:
+* A PCF installation with [Scheduler for PCF](https://network.pivotal.io/products/scheduler-for-pcf) installed and listed in the [Marketplace](http://docs.pivotal.io/devguide/services/#instances)
+* A [Space Developer](http://docs.pivotal.io/pivotalcf/concepts/roles.html#roles) account on the PCF installation
+* An api client such as `curl`
+* An oauth toke for the the org and space containing your app
+* See the Scheduler for PCF [API docs](http://docs.pivotal.io/pivotalcf/scheduler-for-pcf/api) for more details
+
+## <a id='process'></a>The Create-Bind Process
+
+Because every app and service in PCF is scoped to a [space](http://docs.pivotal.io/pivotalcf/concepts/roles.html#spaces), an app can only use a service if an instance of the service exists in the same space. 
+
+The Scheduler for PCF service is a singleton service and only one service instance can be created in a space.
+
+To use Scheduler in a PCF app:
+
+1. Use the [cf CLI](http://docs.pivotal.io/pivotalcf/cf-cli/getting-started.html#login) or [Apps Manager](http://docs.pivotal.io/pivotalcf/customizing/console-login.html) to log into the org and space that contains the app.
+
+1. Make sure an instance of the Scheduler for PCF service exists in the same space as the app.
+   - If the space does not already have a Scheduler for PCF instance, [create](#create) one.
+   - If the space already has a Scheduler for PCF instance, you can [bind](#bind) your app to the existing instance.
+
+2. [Bind](#bind) the app to the Scheduler for PCF service instance.
+
+## <a id='marketplace'></a>Confirm Service Availability
+
+For an app to use a service, 1) the service must be available in the Marketplace for its space and 2) an instance of the service must exist in its space.
+
+You can confirm both of these using the cf CLI as follows.
+
+1. To find out if Scheduler for PCF service is available in the Marketplace:
+   1. Enter `cf marketplace`
+   1. If the output lists `scheduler-for-pcf` in the `service` column, Scheduler for PCF is available. If it is not available, ask your operator to install it.
+
+    <pre class="terminal">
+    $ cf marketplace
+    Getting services from marketplace in org my-org / space my-space as user<span>@</span>example.com...
+    OK
+    service             plans      description
+    [...]
+    scheduler-for-pcf   standard     Scheduler service
+    [...]
+    </pre>
+
+1. To confirm that an Scheduler for PCF instance is running in the space
+    1. Enter `cf services`
+    1. A `scheduler-for-pcf` listing in the `service` column is a service instance of Scheduler in the space.
+
+    <pre class="terminal">
+    $ cf services
+    Getting services in org my-org / space my-space as user<span>@</span>example.com...
+    OK
+    name          service            plan    bound apps    last operation
+    my-instance   scheduler-for-pcf  standard              create succeeded
+    </pre>
+    You can [bind](#bind) your app to the existing instance.
+
+## <a id='create'></a>Create a Service Instance
+
+To create an instance of the Scheduler for PCF service, run `cf create-service`:
+
+1. Enter `cf create-service scheduler-for-pcf standard SERVICE_INSTANCE`  
+
+    Where `SERVICE_INSTANCE` is a name you choose to identify the service instance. This name will appear under `service` \[sic\] in output from `cf services`.
+
+    <pre class="terminal">
+   $ cf create-service scheduler-for-pcf standard my-instance<br>
+    Creating service my-instance in org my-org / space my-space as user<span>@</span>example.com...
+    OK<br>
+   $ cf services<br>
+    Getting services in org my-org / space my-space as user<span>@</span>example.com...
+    OK
+    name          service            plan    bound apps    last operation
+    my-instance   scheduler-for-pcf  standard              create succeeded
+</pre>
+
+    You can only create one instance in a space.  If you attempt to create more than one instance in a space you will get an error response.
+
+## <a id="bind"></a>Bind a Service Instance to Your App
+
+For an app to use a service, you must bind it to a service instance. Do this after you push or re-push the app using `cf push`.
+
+To bind an app to a Scheduler instance run `$ cf bind-service`.
+
+1. Enter `cf bind-service APP SERVICE_INSTANCE`
+
+    Where `APP` is the app you want to use the Scheduler service instance and `SERVICE_INSTANCE` is the name you supplied when you ran `cf create-service`.
+
+    <pre class="terminal">
+   $ cf bind-service my-app my-instance<br>
+    Binding service my-instance to my-app in org my-org / space my-space as user<span>@</span>example.com...
+    OK
+    TIP: Use 'cf push' to ensure your env variable changes take effect
+</pre>
+
+## <a id="list-jobs"></a>Create a new job
+
+To execute tasks related to an App, create a new job related to an apps. Use the CLI to create a job.
+
+1. Enter `cf create-job APP JOB_NAME COMMAND`
+
+    Where `APP` is the app you want to execute a task againstand `JOB_NAME` is the name for your newly created job and COMMAND is the command you wish to execute.
+
+    <pre class="terminal">
+   $ cf create-job my-app my-job "pwd"<br>
+   Creating job myjob for scheduler-api with command ls in org my-org / space my-space as user<span>@</span>example.com...
+   Job Name   App Name        Command
+   my-job      scheduler-api   ls
+   OK
+	</pre>
+
+
+## <a id="list-jobs"></a>List Jobs
+
+Jobs are related to apps and are available to all space developers. Use the CLI to list all jobs in a space.
+
+1. Enter `cf jobs`
+
+    <pre class="terminal">
+   $ cf jobs<br>
+   Listing jobs for org my-org / space my-space as user<span>@</span>example.com...
+   Job Name   App Name        Command
+   my-job      scheduler-api   ls
+   OK
+	</pre>
+
+## <a id="exec-jobs"></a>Execute a job
+
+Jobs can be executed in ad-hoc which is often useful to test the proper configuration of a job prior to scheduling the job for recurring execution.
+
+1. Enter `cf run-job my-job`
+
+    <pre class="terminal">
+    $ cf run-job my-job<br>
+    Enqueuing job my-job for app my-app in org my-org / space my-space as user<span>@</span>example.com...
+    OK
+	</pre>
+
+## <a id="view-job-history"></a>View job history
+
+Every execution of a job is recorded in the schedulers job history and can be easily reviewed for execution status.
+
+1. Enter `cf job-history my-job`
+
+    <pre class="terminal">
+    $ cf job-history my-job<br>
+    Getting scheduled job history for my-job in org my-org / space my-space as user<span>@</span>example.com...
+    1 - 1 of 1 Total Results
+    Execution GUID                     Execution State   Scheduled Time                  Execution Start Time            Execution End Time              Exit Message
+    8a7e808a5b883a25015b89b4a12c0001   SUCCEEDED         Mon, 10 Apr 2017 13:00:00 UTC   Mon, 10 Apr 2017 13:00:00 UTC   Mon, 10 Apr 2017 13:00:01 UTC   202 - Cloud Controller Accepted Task
+	</pre>
+
+## <a id="view-logs"></a>View logs for job execution
+
+Jobs are executed as [CF Tasks](https://docs.run.pivotal.io/devguide/using-tasks.html).  Logs for tasks and jobs can be viewed by view logs for the related App.
+
+1. Enter `cf logs my-job --recent`
+
+    <pre class="terminal">
+    $ cf logs my-job --recent<br>
+    Connected, dumping recent logs for app my-app in org my-org / space my-space as user<span>@</span>example.com...
+    [...]
+    2017-04-19T23:04:13.79-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT Creating container
+2017-04-19T23:04:14.01-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT Successfully created container
+2017-04-19T23:04:14.22-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT bin
+2017-04-19T23:04:14.22-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT db
+2017-04-19T23:04:14.23-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT Exit status 0
+2017-04-19T23:04:14.24-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT Destroying container
+2017-04-19T23:04:14.55-0600 [APP/TASK/cc6fab7f-32a9-4404-4574-b0c430a96cd9 -|- 0d30f4f0-11a4-4d6a-7e77-5e1cdc1aa5ec/0]OUT Successfully destroyed container
+	[...]
+	</pre>	
+
+## <a id="view-logs"></a>Schedule a job
+
+Jobs can be scheduled to execute at any time in the future using a schedule expression. Scheduler for PCF takes cron expressions in the format of `<min> <hours> <Day of month> <month> <Day of week>` To better understand the expression (based on cron) see [Schedule Expressions](https://docs.pivotal.io/scheduler-for-pcf/scheduler-expressions.html)
+
+1. Enter `cf schedule-job my-job "* * ? * *"`
+
+    <pre class="terminal">
+    $ cf schedule-job my-job "* * ? * *"<br>
+    Scheduling job my-job for my-app to execute based on expression * * ? * * in org my-org / space my-space as user<span>@</span>example.com...
+    OK
+	</pre>	
+
+The job will be executed based on all the existing schedules. Schedules also are assigned a guid in order to uniquely identify similar schedules.
+
+## <a id="view-schedules"></a>View Schedules for all jobs in a space.
+
+Schedules for all jobs in a space can be reviewed for accuracy.
+
+1. Enter `cf job-schedules`
+
+    <pre class="terminal">
+    $ cf job-schedules my-job "* * ? * *"<br>
+    Getting scheduled jobs for org my-org / space my-space as user<span>@</span>example.com...
+    App Name: my-app
+    my-job                     ls
+                               2b69e0c2-9664-46bb-4817-54afcedbb65d   * * ? * *
+    OK
+	</pre>
+
+## <a id="delete-job-schedule"></a>Delete a Job Schedule  
+
+When you no longer wish to runa a job on a particular schedule you can delete a specific schedule.
+
+1. Enter `cf delete-job-schedule SCHEDULE_GUID`  
+
+	Where 'SCHEDULE_GUID' is the guid found in the job-schedules command.
+
+    <pre class="terminal">
+    $ cf delete-job-schedule 2b69e0c2-9664-46bb-4817-54afcedbb65d<br>
+    Really delete the schedule 2b69e0c2-9664-46bb-4817-54afcedbb65d / * * ? * * and all associated history?> [yN]: y
+    OK
+	</pre>	
+
+## <a id="delete-job"></a>Delete a job
+
+When a job is no longer needed it can be deleted.
+
+1. Enter `cf delete-job JOB_NAME`  
+
+	Where 'JOB_NAME' is the name of an existing job to be deleted.
+
+    <pre class="terminal">
+    $ cf delete-job my-job<br>
+    Really delete the job my-job with command ls and all associated schedules and history?> [yN]:y
+    OK
+	</pre>
+


### PR DESCRIPTION
This contains the initial docs for Scheduler for PCF.  There are a few broken links that need to be sorted out for API docs and a "cron expressions" page.