### PR TITLE
added direct link for the plugin.

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -13,7 +13,7 @@ To start using Scheduler for PCF, you need the following:
 
 * A PCF deployment with [Scheduler for PCF](https://network.pivotal.io/products/p-scheduler-for-pcf) installed and listed in the [Marketplace](http://docs.pivotal.io/devguide/services/#instances).
 * A [Space Developer](http://docs.pivotal.io/pivotalcf/concepts/roles.html#roles) account.
-* (Optional) The cf CLI v6.23.0 or greater and the Scheduler for PCF CLI plugin installed on your local machine. The Scheduler for PCF CLI plugin is packaged with the Scheduler for PCF tile on Pivotal Network.
+* (Optional) The cf CLI v6.23.0 or greater and the Scheduler for PCF CLI plugin installed on your local machine. The Scheduler for PCF CLI plugin is packaged with the Scheduler for PCF tile on [Pivotal Network](https://network.pivotal.io/products/p-scheduler).
 
 ## <a id='create-service'></a>Create and Bind a Service Instance Using the cf CLI
 


### PR DESCRIPTION
The plugin was linked in a note section on the https://docs.pivotal.io/pcf-scheduler/1-1/using-jobs.html#manage-jobs, but not in the main PreReq section.  Just sync-ing the text. 