### PR TITLE
mention lack of seconds, years in scheduler cron syntax

### DIFF
--- a/docs-content/using-jobs.html.md.erb
+++ b/docs-content/using-jobs.html.md.erb
@@ -51,6 +51,7 @@ For example, to execute a job at noon every day, run the following command:
 
 A single job can have multiple schedules. Each schedule has a GUID to distinguish it from similar schedules.
 
+<p class="note"><strong>Note</strong>: Scheduler for PCF does not support cron expressions with seconds or years.</p>
 <p class="note"><strong>Note</strong>: Scheduled jobs automatically execute in UTC.</p>
 
 ### <a id="list-jobs"></a>View Jobs


### PR DESCRIPTION
Added note about scheduler cron syntax not supporting seconds or years. Not sure I've ever seen two notes on one paragraph before. let me know if you know of a better format for this information. 