### PR TITLE
Add note of Metrics Forwarder Deprecation

### DIFF
--- a/docs-content/monitoring.html.md.erb
+++ b/docs-content/monitoring.html.md.erb
@@ -20,3 +20,5 @@ Scheduler for PCF emits the following metrics:
 | `gauge.scheduler.calls.executed` | The number of calls Scheduler has executed.  | Integer |
 | `gauge.scheduler.calls.failed` | The number of calls Scheduler failed to execute. | Integer |
 | `gauge.scheduler.calls.total` | The number of calls that currently exists in Scheduler. | Integer |
+
+<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF has been deprecated and cannot be installed in PAS v2.5 and higher. This functionality will be unavailable after upgrading to PAS 2.5 and higher. Upgrading to PAS 2.5 will not impact the reliability or health of Scheduler for PCF.</p>

--- a/docs-content/monitoring.html.md.erb
+++ b/docs-content/monitoring.html.md.erb
@@ -21,4 +21,4 @@ Scheduler for PCF emits the following metrics:
 | `gauge.scheduler.calls.failed` | The number of calls Scheduler failed to execute. | Integer |
 | `gauge.scheduler.calls.total` | The number of calls that currently exists in Scheduler. | Integer |
 
-<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF is unsupported as of Pivotal Application Service (PAS) v2.5. This functionality will be unavailable after upgrading to PAS v2.5 and later. Upgrading to PAS v2.5 does not impact the reliability or health of Scheduler for PCF.</p>
+<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF is unsupported as of Pivotal Application Service (PAS) v2.5. This functionality is unavailable after upgrading to PAS v2.5 or later. Upgrading to PAS v2.5 does not impact the reliability or health of Scheduler for PCF.</p>

--- a/docs-content/monitoring.html.md.erb
+++ b/docs-content/monitoring.html.md.erb
@@ -21,4 +21,4 @@ Scheduler for PCF emits the following metrics:
 | `gauge.scheduler.calls.failed` | The number of calls Scheduler failed to execute. | Integer |
 | `gauge.scheduler.calls.total` | The number of calls that currently exists in Scheduler. | Integer |
 
-<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF has been deprecated and cannot be installed in PAS v2.5 and higher. This functionality will be unavailable after upgrading to PAS 2.5 and higher. Upgrading to PAS 2.5 will not impact the reliability or health of Scheduler for PCF.</p>
+<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF is unsupported as of PAS 2.5. This functionality will be unavailable after upgrading to PAS 2.5 and higher. Upgrading to PAS 2.5 will not impact the reliability or health of Scheduler for PCF.</p>

--- a/docs-content/monitoring.html.md.erb
+++ b/docs-content/monitoring.html.md.erb
@@ -21,4 +21,4 @@ Scheduler for PCF emits the following metrics:
 | `gauge.scheduler.calls.failed` | The number of calls Scheduler failed to execute. | Integer |
 | `gauge.scheduler.calls.total` | The number of calls that currently exists in Scheduler. | Integer |
 
-<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF is unsupported as of PAS 2.5. This functionality will be unavailable after upgrading to PAS 2.5 and higher. Upgrading to PAS 2.5 will not impact the reliability or health of Scheduler for PCF.</p>
+<p class="note"><strong>Note:</strong> Metrics Forwarder for PCF is unsupported as of Pivotal Application Service (PAS) v2.5. This functionality will be unavailable after upgrading to PAS v2.5 and later. Upgrading to PAS v2.5 does not impact the reliability or health of Scheduler for PCF.</p>


### PR DESCRIPTION
Noted that Metrics Forwarder will be unavailable in PAS 2.5+ and that Scheduler should still work even without monitoring. 