### PR TITLE
Rebranding updates

### DIFF
--- a/docs-content/architecture.html.md.erb
+++ b/docs-content/architecture.html.md.erb
@@ -3,11 +3,11 @@ title: Architecture
 owner: PCF Autoscaler and Scheduler
 ---
 
-This topic describes the architecture of Scheduler for Pivotal Cloud Foundry (PCF).
+This topic describes the architecture of Pivotal Scheduler.
 
 ## <a id="topology"></a> HA Topology
 
-In a highly available resource configuration, the Scheduler for PCF service uses the following:
+In a highly available resource configuration, the Pivotal Scheduler service uses the following:
 
 * Three Scheduler instances, each running the Scheduler HTTP API server and a Scheduler Engine.
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,15 +1,15 @@
 ---
-title: Scheduler for PCF 
+title: Pivotal Scheduler 
 owner: PCF Autoscaler and Scheduler
 ---
-This documentation describes Scheduler for Pivotal Cloud Foundry (PCF).
+This documentation describes Pivotal Scheduler.
 
 ## <a id='overview'></a>Overview
 
-Scheduler for PCF is a service for scheduling the execution of Diego tasks, 
+Pivotal Scheduler is a service for scheduling the execution of Diego tasks, 
 such as database migrations, emails, or batch jobs, as well as the execution of outbound HTTP calls.
 
-Scheduler for PCF enables developers to do the following:
+Pivotal Scheduler enables developers to do the following:
 
 * Create, run, and schedule jobs and view job history.
 * Create, run, and schedule calls and view call history.
@@ -20,7 +20,7 @@ and the [Scheduler HTTP API](http://docs.pivotal.io/pcf-scheduler/1-1/api).
 
 ## <a id="snapshot"></a>Product Snapshot
 
-The following table provides version and version-support information about Scheduler for PCF.
+The following table provides version and version-support information about Pivotal Scheduler.
 
 <table class="nice">
     <th>Element</th>
@@ -48,11 +48,11 @@ The following table provides version and version-support information about Sched
 
 ## <a id="reqs"></a>Requirements
 
-Scheduler for PCF requires a MySQL database.
+Pivotal Scheduler requires a MySQL database.
 
 You can use either of the following:
 
-+ MySQL for PCF v2.3 or later. See [MySQL for PCF](http://docs.pivotal.io/p-mysql). 
++ MySQL for Pivotal Platform v2.3 or later. See [MySQL for Pivotal Platform](http://docs.pivotal.io/p-mysql). 
 + An external MySQL database
 
 ## <a id="limitations"></a>Limitations
@@ -69,5 +69,5 @@ such as Ruby or Python, you should do the following:
     the cf CLI after you create Scheduler jobs for it.
 
 * The maximum number of tasks that you can schedule is determined by the memory 
-and disk quotas in the Scheduler for PCF org and space. 
+and disk quotas in the Pivotal Scheduler org and space. 
 For more information, see [Running Tasks](http://docs.pivotal.io/pivotalcf/devguide/using-tasks.html#manage-tasks).

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -1,33 +1,33 @@
 ---
-title: Installing and Configuring Scheduler for PCF
+title: Installing and Configuring Pivotal Scheduler
 owner: PCF Autoscaler and Scheduler
 ---
 
-This topic describes how to install and configure Scheduler for Pivotal Cloud Foundry (PCF).
+This topic describes how to install and configure Pivotal Scheduler.
 
 ##<a id='prereqs'></a> Prerequisites
 
-Before you install Scheduler for PCF v1.2, you must have a MySQL for PCF v2.x tile with **TLS Options** set to **Optional** or **Not Configured**. See [Configure Security](https://docs.pivotal.io/p-mysql/install-config.html#security).
+Before you install Pivotal Scheduler v1.2, you must have a MySQL for Pivotal Platform v2.x tile with **TLS Options** set to **Optional** or **Not Configured**. See [Configure Security](https://docs.pivotal.io/p-mysql/install-config.html#security).
 
-For more information about installing and configuring a MySQL for PCF v2.x tile, see [Installing and Configuring MySQL for PCF](https://docs.pivotal.io/p-mysql/install-config.html).
+For more information about installing and configuring a MySQL for Pivotal Platform v2.x tile, see [Installing and Configuring MySQL for Pivotal Platform](https://docs.pivotal.io/p-mysql/install-config.html).
 
 
-## <a id="download-install"></a> Download and Install Scheduler for PCF
+## <a id="download-install"></a> Download and Install Pivotal Scheduler
 
-<p class="note"><strong>Note:</strong> Before using Scheduler for PCF v1.2.3 and later, you must update any BOSH add-ons to support Xenial stemcells. See <a href="./upgrade_scheduler.html#update-addons">Update Add-ons to Run with Xenial Stemcell</a>.</p>
+<p class="note"><strong>Note:</strong> Before using Pivotal Scheduler v1.2.3 and later, you must update any BOSH add-ons to support Xenial stemcells. See <a href="./upgrade_scheduler.html#update-addons">Update Add-ons to Run with Xenial Stemcell</a>.</p>
 
 1. Download the product file from [Pivotal Network](https://network.pivotal.io/products/p-scheduler-for-pcf).
 
 1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file. 
 
-1. Under the **Import a Product** button, click **+** next to the version number of Scheduler for PCF. 
+1. Under the **Import a Product** button, click **+** next to the version number of Pivotal Scheduler. 
   This adds the tile to your staging area.
 
-1. Click the newly added **Scheduler for PCF** tile.
+1. Click the newly added **Pivotal Scheduler** tile.
 
-## <a id="config-tile"></a> Configure Scheduler for PCF
+## <a id="config-tile"></a> Configure Pivotal Scheduler
 
-Follow the steps below to configure the Scheduler for PCF tile.
+Follow the steps below to configure the Pivotal Scheduler tile.
 
 ###<a id="azs"></a> Configure AZs and Networks
 
@@ -72,11 +72,11 @@ Follow the steps below to choose an Availability Zone (AZ) to run the Scheduler 
       </tr>
       <tr>
         <td><strong>Enable outbound HTTP calls</strong></td>
-        <td>The field is enabled by default. Disable this feature if you want to prevent users from scheduling outbound HTTP calls from the Scheduler for PCF service.</td>
+        <td>The field is enabled by default. Disable this feature if you want to prevent users from scheduling outbound HTTP calls from the Pivotal Scheduler service.</td>
       </tr>
       <tr>
         <td><strong>MySQL Service Plan Name</strong></td>
-        <td>Enter the name of your MySQL for PCF service plan, which is used to provision a database for persistent storage of Scheduler data, including jobs, calls, and history.</td>
+        <td>Enter the name of your MySQL for Pivotal Platform service plan, which is used to provision a database for persistent storage of Scheduler data, including jobs, calls, and history.</td>
       </tr>
     </table>
 1. Click **Save**.
@@ -91,13 +91,13 @@ Follow the steps below to choose an Availability Zone (AZ) to run the Scheduler 
 
 ###<a id="stemcell"></a> Verify Stemcell Version
 
-To verify that you have the correct stemcell version for the Scheduler for PCF tile, do the following:
+To verify that you have the correct stemcell version for the Pivotal Scheduler tile, do the following:
 
 1. Click **Stemcell**.
 
 1. Verify the settings.
 
-    Scheduler for PCF v1.2.3 and later requires a Xenial stemcell. Scheduler for PCF v1.2.2 and earlier requires a Trusty stemcell.
+    Pivotal Scheduler v1.2.3 and later requires a Xenial stemcell. Pivotal Scheduler v1.2.2 and earlier requires a Trusty stemcell.
     If you need to import a new stemcell version, do the following:  
 
 1. Download the stemcell from [Pivotal Network](https://network.pivotal.io/products).

--- a/docs-content/using-calls.html.md.erb
+++ b/docs-content/using-calls.html.md.erb
@@ -3,13 +3,13 @@ title: Scheduling Calls
 owner: PCF Autoscaler and Scheduler
 ---
 
-This topic provides instructions for managing outbound HTTP calls in Scheduler for Pivotal Cloud Foundry (PCF).
+This topic provides instructions for managing outbound HTTP calls in Pivotal Scheduler.
 
 ## <a id="manage-calls"></a>Manage Calls
 
-You can use Scheduler for PCF to schedule execution of HTTP calls to external HTTP services. See the following sections to learn more about creating, running, and scheduling calls and viewing call history.
+You can use Pivotal Scheduler to schedule execution of HTTP calls to external HTTP services. See the following sections to learn more about creating, running, and scheduling calls and viewing call history.
 
-<p class="note"><strong>Note</strong>: If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing calls, you must install the Scheduler for PCF CLI plugin on your local machine. This plugin is packaged with the Scheduler for PCF tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Scheduler for PCF topic.</p>
+<p class="note"><strong>Note</strong>: If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing calls, you must install the Pivotal Scheduler CLI plugin on your local machine. This plugin is packaged with the Pivotal Scheduler tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Pivotal Scheduler topic.</p>
 
 ### <a id="create-calls"></a>Create a Call
 
@@ -33,7 +33,7 @@ OK
 
 ### <a id="schedule-call"></a>Schedule a Call
 
-You can schedule a call to execute at any time using a schedule expression. Scheduler for PCF requires Cron expressions in the `MIN HOUR DAY-OF-MONTH MONTH DAY-OF-WEEK` format.
+You can schedule a call to execute at any time using a schedule expression. Pivotal Scheduler requires Cron expressions in the `MIN HOUR DAY-OF-MONTH MONTH DAY-OF-WEEK` format.
 
 For example, to execute a call at noon every day, run the following command:
 

--- a/docs-content/using-jobs.html.md.erb
+++ b/docs-content/using-jobs.html.md.erb
@@ -3,13 +3,13 @@ title: Scheduling Jobs
 owner: PCF Autoscaler and Scheduler
 ---
 
-This topic provides instructions for managing jobs in Scheduler for Pivotal Cloud Foundry (PCF).
+This topic provides instructions for managing jobs in Pivotal Scheduler.
 
 ## <a id="manage-jobs"></a>Manage Jobs
 
-You can use Scheduler for PCF to schedule execution of tasks on PCF, including database migrations, emails, and batch jobs. See the following sections to learn more about creating, running, and scheduling jobs and viewing job history.
+You can use Pivotal Scheduler to schedule execution of tasks on the Pivotal Platform, including database migrations, emails, and batch jobs. See the following sections to learn more about creating, running, and scheduling jobs and viewing job history.
 
-<p class="note"><strong>Note</strong>: If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing jobs, you must install the Scheduler for PCF CLI plugin on your local machine. This plugin is packaged with the Scheduler for PCF tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Scheduler for PCF topic.</p>
+<p class="note"><strong>Note</strong>: If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing jobs, you must install the Pivotal Scheduler CLI plugin on your local machine. This plugin is packaged with the Pivotal Scheduler tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Pivotal Scheduler topic.</p>
 
 ### <a id="create-jobs"></a>Create a Job
 
@@ -43,7 +43,7 @@ OK
 
 ### <a id="schedule-job"></a>Schedule a Job
 
-You can schedule a job to execute at any time using a schedule expression. Scheduler for PCF requires Cron expressions in the `MIN HOUR DAY-OF-MONTH MONTH DAY-OF-WEEK` format.
+You can schedule a job to execute at any time using a schedule expression. Pivotal Scheduler requires Cron expressions in the `MIN HOUR DAY-OF-MONTH MONTH DAY-OF-WEEK` format.
 
 For example, to execute a job at noon every day, run the following command:
 
@@ -106,7 +106,7 @@ Connected, dumping recent logs for app my-app in org my-org / space my-space as 
 [...]
 </pre>
 
-<p class="note"><strong>Note</strong>: Scheduler for PCF jobs are executed as <a href="https://docs.pivotal.io/pivotalcf/devguide/using-tasks.html">CF Tasks</a>.</p>
+<p class="note"><strong>Note</strong>: Pivotal Scheduler jobs are executed as <a href="https://docs.pivotal.io/pivotalcf/devguide/using-tasks.html">CF Tasks</a>.</p>
 
 ### <a id="delete-job"></a>Delete a Job
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,32 +1,32 @@
 ---
-title: Using Scheduler for PCF
+title: Using Pivotal Scheduler
 owner: PCF Autoscaler and Scheduler
 ---
 
-This topic provides instructions for using Scheduler for Pivotal Cloud Foundry (PCF).
+This topic provides instructions for using Pivotal Scheduler.
 
 You can interact with the service through the Cloud Foundry Command Line Interface (cf CLI), [Apps Manager](https://docs.pivotal.io/pivotalcf/console/manage-apps.html#enable-scheduling), and the [Scheduler HTTP API](http://docs.pivotal.io/pcf-scheduler/1-1/api/) to configure jobs and outbound HTTP calls and to review history. For general information, see [Managing Service Instances with the cf CLI](http://docs.pivotal.io/devguide/services/managing-services.html).
 
 ## <a id="prereqs"></a>Prerequisites
 
-To start using Scheduler for PCF, you need the following:
+To start using Pivotal Scheduler, you need the following:
 
-* A PCF deployment with [Scheduler for PCF](https://network.pivotal.io/products/p-scheduler-for-pcf) installed and listed in the [Marketplace](http://docs.pivotal.io/devguide/services/#instances).
+* A PCF deployment with [Pivotal Scheduler](https://network.pivotal.io/products/p-scheduler-for-pcf) installed and listed in the [Marketplace](http://docs.pivotal.io/devguide/services/#instances).
 * A [Space Developer](http://docs.pivotal.io/pivotalcf/concepts/roles.html#roles) account.
-* (Optional) The cf CLI v6.23.0 or greater and the Scheduler for PCF CLI plugin installed on your local machine. The Scheduler for PCF CLI plugin is packaged with the Scheduler for PCF tile on [Pivotal Network](https://network.pivotal.io/products/p-scheduler).
+* (Optional) The cf CLI v6.23.0 or greater and the Pivotal Scheduler CLI plugin installed on your local machine. The Pivotal Scheduler CLI plugin is packaged with the Pivotal Scheduler tile on [Pivotal Network](https://network.pivotal.io/products/p-scheduler).
 
 ## <a id='create-service'></a>Create and Bind a Service Instance Using the cf CLI
 
 Every app and service in PCF is scoped to a [space](http://docs.pivotal.io/pivotalcf/concepts/roles.html#spaces). This means that an app can use a service only if an instance of the service exists in the same space.
 
-The Scheduler for PCF service is a singleton service. Only one service instance can be created in a space.
+The Pivotal Scheduler service is a singleton service. Only one service instance can be created in a space.
 
 ### <a id='run-marketplace'></a>Confirm Service Availability
 
-For apps to use a service, the service must be available in the Marketplace. To confirm the availability of Scheduler for PCF, perform the following steps:
+For apps to use a service, the service must be available in the Marketplace. To confirm the availability of Pivotal Scheduler, perform the following steps:
 
 1. Run `cf marketplace` from the command line.
-1. If the output lists `scheduler-for-pcf` in the `service` column, Scheduler for PCF is available. If the service is not available, install it. See [Installing and Configuring Scheduler for PCF](./installing.html) for more information.
+1. If the output lists `scheduler-for-pcf` in the `service` column, Pivotal Scheduler is available. If the service is not available, install it. See [Installing and Configuring Pivotal Scheduler](./installing.html) for more information.
 
     <pre class="terminal">
     $ cf marketplace
@@ -40,7 +40,7 @@ For apps to use a service, the service must be available in the Marketplace. To 
 
 ### <a id='create'></a>Create a Service Instance
 
-To create an instance of the Scheduler for PCF service, run `cf create-service scheduler-for-pcf standard SERVICE-INSTANCE-NAME`, replacing `SERVICE-INSTANCE-NAME` with a name of your choice. After you create the service instance, this instance name appears under `name` in the output of the `cf services` command.
+To create an instance of the Pivotal Scheduler service, run `cf create-service scheduler-for-pcf standard SERVICE-INSTANCE-NAME`, replacing `SERVICE-INSTANCE-NAME` with a name of your choice. After you create the service instance, this instance name appears under `name` in the output of the `cf services` command.
 
 See the following example:
 
@@ -61,7 +61,7 @@ You can create only one instance in a space. If you attempt to create more than 
 
 For an app to use a service, you must bind it to a service instance. Do this after you push or re-push the app using `cf push`.
 
-To bind an app to a Scheduler for PCF instance, run `cf bind-service APP-NAME SERVICE-INSTANCE-NAME`, replacing `APP-NAME` with the name of the app you want to use the Scheduler for PCF service for and `SERVICE-INSTANCE-NAME` with the name you provided when you ran `cf create-service`.
+To bind an app to a Pivotal Scheduler instance, run `cf bind-service APP-NAME SERVICE-INSTANCE-NAME`, replacing `APP-NAME` with the name of the app you want to use the Pivotal Scheduler service for and `SERVICE-INSTANCE-NAME` with the name you provided when you ran `cf create-service`.
 
 <pre class="terminal">
 $ cf bind-service my-app my-instance<br>
@@ -72,10 +72,10 @@ TIP: Use 'cf push' to ensure your env variable changes take effect
 
 ## <a id="manage-jobs"></a>Manage Jobs and Calls
 
-For information about the CLI operations that you can perform to manage jobs and calls in Scheduler for PCF, see [Using Jobs](using-jobs.html) and [Using Calls](using-calls.html).
+For information about the CLI operations that you can perform to manage jobs and calls in Pivotal Scheduler, see [Using Jobs](using-jobs.html) and [Using Calls](using-calls.html).
 
-If you want to manage jobs and calls through the Scheduler HTTP API, see the [Scheduler for PCF API Documentation](http://docs.pivotal.io/pcf-scheduler/1-1/api/).
+If you want to manage jobs and calls through the Scheduler HTTP API, see the [Pivotal Scheduler API Documentation](http://docs.pivotal.io/pcf-scheduler/1-1/api/).
 
-## <a id="using-am"></a> Using Scheduler for PCF in Apps Manager
+## <a id="using-am"></a> Using Pivotal Scheduler in Apps Manager
 
-For information about binding Scheduler for PCF to your app and scheduling tasks through Apps Manager, see [Managing Apps and Service Instances Using Apps Manager](http://docs.pivotal.io/pivotalcf/console/manage-apps.html#enable-scheduling).
+For information about binding Pivotal Scheduler to your app and scheduling tasks through Apps Manager, see [Managing Apps and Service Instances Using Apps Manager](http://docs.pivotal.io/pivotalcf/console/manage-apps.html#enable-scheduling).


### PR DESCRIPTION
Changed Scheduler for PCF to Pivotal Scheduler and MySQL for PCF to MySQL for Pivotal Platform throughout.

NOTE: I did not change the following files: 
- upgrade
- release notes
- monitoring
...because there are enough references to old and new file names that I wanted to be more careful with that and wait until there are new file names (potentially) for Scheduler downloads. Monitoring is a tough subject - it's only possible on PAS 2.4 and below, and we'll have to see if we support that in future minor versions of Scheduler. 