### PR TITLE
Updated brand on release notes and clarified "Using" content

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,9 +1,42 @@
 ---
-title: Scheduler for PCF Release Notes
+title: Pivotal Scheduler Release Notes
 owner: PCF Autoscaler and Scheduler
 ---
 
-This topic contains release notes for Scheduler for Pivotal Cloud Foundry (PCF).
+This topic contains release notes for Pivotal Scheduler.
+## <a id="1-2-30"></a>v1.2.30
+
+**Release Date:** October 15, 2019
+
+### Features included in this release:
+
+New features and changes in this release:
+
+* Security fixes
+* Additional smoke tests
+
+### Known Issues
+
+There are no known issues for this release.
+
+## <a id="1-2-28"></a>v1.2.28
+
+**Release Date:** September 09, 2019
+
+### Features included in this release:
+
+New features and changes in this release:
+
+* Fix version number inconsistency
+* Bumped CF CLI to v6.45.0
+* Removed job to automatically create Metrics Forwarder service binding
+* Added ability to enable tracing of external service calls to aid in debugging
+* Improved granularity of smoke tests
+
+### Known Issues
+
+There are no known issues for this release.
+
 ## <a id="1-2-27"></a>v1.2.27
 
 **Release Date:** July 30, 2019
@@ -12,9 +45,9 @@ This topic contains release notes for Scheduler for Pivotal Cloud Foundry (PCF).
 
 New features and changes in this release:
 
-* Bumped CF CLI to v6.45.0 
-* Removed job to automatically create Metrics Forwarder service binding 
-* Added ability to enable tracing of external service calls to aid in debugging 
+* Bumped CF CLI to v6.45.0
+* Removed job to automatically create Metrics Forwarder service binding
+* Added ability to enable tracing of external service calls to aid in debugging
 * Improved granularity of smoke tests
 
 ### Known Issues

--- a/docs-content/using-jobs.html.md.erb
+++ b/docs-content/using-jobs.html.md.erb
@@ -123,10 +123,11 @@ OK
 
 ### <a id="delete-schedule"></a>Delete a Job Schedule  
 
-You can delete a specific schedule by running `cf delete-job-schedule SCHEDULE-GUID`, where `SCHEDULE-GUID` is the GUID found in the output of the `cf job-schedules` command. See the following example:
+You can delete a specific schedule by running `cf delete-job-schedule JOB-NAME SCHEDULE-GUID`, where `JOB-NAME` is the name of the job and `SCHEDULE-GUID` is the GUID found in the output of the `cf job-schedules` command. See the following example:
 
 <pre class="terminal">
-$ cf delete-job-schedule 2b69e0c2-9664-46bb-4817-54afcedbb65d<br>
+$ cf delete-job-schedule my-job 2b69e0c2-9664-46bb-4817-54afcedbb65d<br>
 Really delete the schedule 2b69e0c2-9664-46bb-4817-54afcedbb65d / 0 12 ? * * and all associated history?> [yN]: y
+Deleting schedule 2b69e0c2-9664-46bb-4817-54afcedbb65d for job my-job in org test / space scheduler as admin
 OK
 </pre>	


### PR DESCRIPTION
Added some clarity to using the Scheduler docs. 

Rebranded and updated the release notes page. 