### PR TITLE
Add Upgrade step and Rebrand [#165189840]

### DIFF
--- a/docs-content/upgrade_scheduler.html.md.erb
+++ b/docs-content/upgrade_scheduler.html.md.erb
@@ -1,10 +1,10 @@
 ---
 breadcrumb: PCF Services
-title: Upgrading to Scheduler for PCF v1.2
+title: Upgrading to Pivotal Scheduler v1.2
 ---
-This topic explains how to upgrade Scheduler for PCF. It also explains
+This topic explains how to upgrade Pivotal Scheduler. It also explains
 how Scheduler for PCF v1.2 automatically migrates data from a MySQL for PCF v1 database
-to a MySQL for PCF v2 database. MySQL for PCF v1 has reached its End of Availability.
+to a MySQL for Pivotal Platform v2 database. MySQL for PCF v1 has reached its End of Availability.
 This migration removes dependency on MySQL for PCF v1.
 
 ##<a id="Prerequisites"></a>Prerequisites
@@ -19,22 +19,22 @@ Before you upgrade to Scheduler v1.2, you must have the following:
 ##<a id="backup"></a>(Optional) Back up MySQL for PCF Database
 
 Pivotal recommends backing up your MySQL for PCF database before installing
-Scheduler for PCF v1.2.
+Pivotal Scheduler v1.2.
 This is because upgrading your Scheduler for PCF installation from v1.1 to v1.2
-triggers automatic migration of your data to a MySQL for PCF v2.x database.
+triggers automatic migration of your data to a MySQL for Pivotal Platform v2.x database.
 
 To back up your MySQL for PCF database, do one of the following:
 
 + If you are backing up a MySQL for PCF v1.x database,
 see [Perform Manual Backup](http://docs.pivotal.io/p-mysql/1-10/backup.html#manual-process).
-+ If you are backing up a MySQL for PCF v2.x database,
++ If you are backing up a MySQL for Pivotal Platform v2.x database,
 see [Manual Backup](https://docs.pivotal.io/p-mysql/backup-and-restore.html#manual-backup).
 
 ## <a id="update-addons"></a>Update Add-Ons to Run with Xenial Stemcell
 
-Scheduler for PCF v1.2.3 and later requires a Xenial stemcell.
+Pivotal Scheduler v1.2.3 and later requires a Xenial stemcell.
 If you are using any of the following BOSH add-ons with your PCF deployment,
-you must update the add-on definition to include the Xenial stemcell before you deploy Scheduler for PCF v1.2.3:
+you must update the add-on definition to include the Xenial stemcell before you deploy Pivotal Scheduler v1.2.3:
 
 + File Integrity Monitoring for PCF Add-on.
   For update instructions,
@@ -46,14 +46,14 @@ you must update the add-on definition to include the Xenial stemcell before you 
   For update instructions,
   see [Updating IPsec Add-on for PCF to Run with Xenial Stemcells](https://docs.pivotal.io/addon-ipsec/updating-for-xenial.html).
 
-##<a id="upgrade_scheduler"></a>Upgrade to Scheduler for PCF v1.2
+##<a id="upgrade_scheduler"></a>Upgrade to Pivotal Scheduler v1.2
 
-During upgrade, Scheduler for PCF automatically migrates your data from
-MySQL for PCF v1.x to MySQL for PCF v2.x.
+During upgrade, Pivotal Scheduler automatically migrates your data from
+MySQL for PCF v1.x to MySQL for Pivotal Platform v2.x.
 
-During the upgrade, Scheduler for PCF detects your MySQL for PCF v1.x service binding.
+During the upgrade, Pivotal Scheduler detects your MySQL for PCF v1.x service binding.
 It then automatically migrates the MySQL for PCF v1.x database instance to a
-MySQL for PCF v2.x instance.
+MySQL for Pivotal Platform v2.x instance.
 The errand migrates the database and executes smoke tests.
 When the migration has completed successfully, the errand
 removes the service binding to the MySQL for PCF v1.x instance.
@@ -64,19 +64,21 @@ To upgrade from Scheduler for PCF v1.1 to v1.2, do the following:
 and import it into the Ops Manager Stemcell Library.
 For instructions, see [Update Stemcell](./installing.html#stemcell).
 
-1. Install MySQL for PCF v2.3 or later in the same PCF environment as
+1. Install MySQL for Pivotal Platform v2.3 or later in the same PCF environment as
 your MySQL for PCF v1.x service instance.
-In the **Security** pane in the MySQL for PCF v2.x tile,
+In the **Security** pane in the MySQL for Pivotal Platform v2.x tile,
 set **TLS Options** to **Optional** or **Not Configured**.
-For information about installing MySQL for PCF v2.x,
-see [Installing and Configuring MySQL for PCF](http://docs.pivotal.io/p-mysql/install-config.html).
+For information about installing MySQL for Pivotal Platform v2.x,
+see [Installing and Configuring MySQL for Pivotal Platform](http://docs.pivotal.io/p-mysql/install-config.html).
 
-1. Upgrade Scheduler for PCF to v1.2 with all errands enabled.
+1. Add the new database details to the Scheduler Configuration. Update the configuration for the Pivotal Scheduler tile under Scheduler Configuration > Database Source to include the MySQL for Pivotal Platform service name and the desired service plan name in order to trigger the migration (I.E. p.mysql, db-small). MySQL for PCF plans can be found in the settings for the MySQL tile or by checking the output of `cf marketplace` under `plans` using the cf cli. 
+
+1. Upgrade Pivotal Scheduler to v1.2 with all errands enabled.
 For general information about upgrading
 a tile,
 see [Upgrading PCF Products](https://docs.pivotal.io/pivotalcf/customizing/upgrading-products.html#other-products).
 
 	<p class="note"><strong>Note:</strong> All <strong>Post-Deploy Errands</strong> must be enabled
-    to migrate from a MySQL for PCF v1.x database to MySQL for PCF v2.x database.
-	These settings are in the Scheduler for PCF <strong>Errands</strong> pane of
-    the Scheduler for PCF tile.</p>
+    to migrate from a MySQL for PCF v1.x database to MySQL for Pivotal Platform v2.x database.
+	These settings are in the Pivotal Scheduler <strong>Errands</strong> pane of
+    the Pivotal Scheduler tile.</p>


### PR DESCRIPTION
- Added step to configure new MySQL DB before upgrading
- Rebranded Scheduler for PCF -> Pivotal Scheduler for v 1.2.x - left it alone for 1.1.x
- Rebranded MySQL for PCF -> MySQL for Pivotal Platform for v2 - left it alone for v1

I need help back-porting this change to the 1.2 branch. 