### PR TITLE
Add note about idempotency of tasks [#168608090]

### DIFF
--- a/docs-content/using-calls.html.md.erb
+++ b/docs-content/using-calls.html.md.erb
@@ -9,7 +9,7 @@ This topic provides instructions for managing outbound HTTP calls in Pivotal Sch
 
 You can use Pivotal Scheduler to schedule execution of HTTP calls to external HTTP services. See the following sections to learn more about creating, running, and scheduling calls and viewing call history.
 
-<p class="note"><strong>Note</strong>: If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing calls, you must install the Pivotal Scheduler CLI plugin on your local machine. This plugin is packaged with the Pivotal Scheduler tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Pivotal Scheduler topic.</p>
+If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing calls, you must install the Pivotal Scheduler CLI plugin on your local machine. This plugin is packaged with the Pivotal Scheduler tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Pivotal Scheduler topic.
 
 ### <a id="create-calls"></a>Create a Call
 

--- a/docs-content/using-jobs.html.md.erb
+++ b/docs-content/using-jobs.html.md.erb
@@ -9,7 +9,9 @@ This topic provides instructions for managing jobs in Pivotal Scheduler.
 
 You can use Pivotal Scheduler to schedule execution of tasks on the Pivotal Platform, including database migrations, emails, and batch jobs. See the following sections to learn more about creating, running, and scheduling jobs and viewing job history.
 
-<p class="note"><strong>Note</strong>: If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing jobs, you must install the Pivotal Scheduler CLI plugin on your local machine. This plugin is packaged with the Pivotal Scheduler tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Pivotal Scheduler topic.</p>
+If you want to use the Cloud Foundry Command Line Interface (cf CLI) for managing jobs, you must install the Pivotal Scheduler CLI plugin on your local machine. This plugin is packaged with the Pivotal Scheduler tile on <a href="https://network.pivotal.io/products/p-scheduler-for-pcf">Pivotal Network</a>. For more information, see the <a href="using.html#prereqs">Prerequisites</a> section of the Using Pivotal Scheduler topic.
+
+<p class="note"><strong>Note:</strong> Pivotal Scheduler does not follow the lifecycle of a task beyond submitting it to the Cloud Controller API. Because of this, Scheduler doesn't take into account the outcome of previously run jobs and assumes that scheduled jobs are idempotent and re-runnable. Jobs that are not idempotent may result in unintended consequences even if they complete successfully. </p>
 
 ### <a id="create-jobs"></a>Create a Job
 


### PR DESCRIPTION
-Added note about idempotency - the idea that tasks will run whether or not you want them to when they're scheduled, and the associated impact on the design of that task. 
Converted Note about CLI to a paragraph. 

Please help me back-port this to v 1.2 of the docs. 