### PR TITLE
Should remove the release note - Remove “test-scheduler-diagnostics” …

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -18,7 +18,6 @@ This topic contains release notes for Scheduler.
 - **Bug Fix** smoke tests should not take so long when fetching logs
 - **Bug Fix** deployment errand should fail when `cf push` fails
 - **Bump** Go to 1.14.2
-- **Remove** "test-scheduler-diagnostics" BOSH errand
 
 ### Known Issues
 


### PR DESCRIPTION
…BOSH errand

According to the actual fix for the release note - Remove “test-scheduler-diagnostics” BOSH errand, it seems that the removed errand was an internal errand which was used to build Scheduler products and was not appeared at Errand section of Scheduler tile.
https://github.com/pivotal-cf/pcf-scheduler-release/commit/15b66623eeaaf2f40fe58d00f9a0b9e0f3dca01b
https://www.pivotaltracker.com/n/projects/2430225/stories/172390146

So this removal is nothing to do with actual end users.

I think the release note - Remove “test-scheduler-diagnostics” BOSH errand - should be removed not to confuse the actual end users.