### PR TITLE
Update a subnet for the Scheduler Errands

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -54,7 +54,7 @@ Follow the steps below to choose an Availability Zone (AZ) to run the Scheduler 
       </tr>
       <tr>
         <td><strong>Network</strong></td>
-        <td>Select a subnet for the Scheduler Errands. Use the subnet that includes the Elastic Runtime component VMs.</td>
+        <td>Select a subnet for the Scheduler Errands. Use the subnet that includes the VMware Tanzu Application Service for VMs (TAS for VMs) component VMs.</td>
       </tr>
     </table>
 


### PR DESCRIPTION
Now the recommended network to be used for Scheduler Errands should be "the subnet that includes the VMware Tanzu Application Service for VMs (TAS for VMs) component VMs" rather than "the subnet that includes the Elastic Runtime component VMs."