### PR TITLE
Document create-job memory and disk limit flags

### DIFF
--- a/docs-content/using-jobs.html.md.erb
+++ b/docs-content/using-jobs.html.md.erb
@@ -20,7 +20,17 @@ To execute a task related to an app, create a job by running the `cf create-job 
   * `APP-NAME` is the app you want to execute a task against.
   * `JOB-NAME` is the name for your job.
   * `COMMAND` is the command you want to execute.
-    
+
+With Scheduler `1.2.33` and newer, Disk and memory limits can be configured via the following optional command flags.
+
+- `--memory LIMIT`, `-m LIMIT` sets the task memory limit.
+- `--disk LIMIT`, `-k LIMIT` sets the task disk limit.
+
+The value must be an integer and be suffixed by a unit (MB for Megabytes or GB for Gigabytes).
+For example, `--memory 1024MB` sets a memory limit of 1024 megabytes and `--disk 5GB` sets a disk limit of 5 gigabytes.
+
+If the neither memory nor disk limits are set, the platform defaults will be used.
+
 See the following example:
 
 <pre class="terminal">

--- a/docs-content/using-jobs.html.md.erb
+++ b/docs-content/using-jobs.html.md.erb
@@ -21,7 +21,7 @@ To execute a task related to an app, create a job by running the `cf create-job 
   * `JOB-NAME` is the name for your job.
   * `COMMAND` is the command you want to execute.
 
-With Scheduler `1.2.33` and newer, Disk and memory limits can be configured via the following optional command flags.
+With Scheduler `1.2.33` and newer, disk and memory limits can be configured via the following optional command flags.
 
 - `--memory LIMIT`, `-m LIMIT` sets the task memory limit.
 - `--disk LIMIT`, `-k LIMIT` sets the task disk limit.


### PR DESCRIPTION
[#173722699](https://www.pivotaltracker.com/story/show/173722699)

I am not sure what the right way to reference the platform would be?
It looks like we need to do quite a few changes to fix the references to "Pivotal Platform." In the interim, I think it is clear enough to just refer to the "platform."

Also I think it is okay to leave the examples as is without using the flags. The `cf push` docs do not seem to have an example of using analogous flags and the `cf push` reference has a similarly concise description of the analogous flags.