### PR TITLE
Scheduler is not guaranteed to work with MariaDB

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -13,7 +13,7 @@ Before you install Pivotal Scheduler v1.2, you must have one of the following:
 
 + An external MySQL database with TLS disabled.
 
-<p class="note"><strong>Note:</strong> Pivotal Scheduler is compatible with MariaDB and MySQL for Pivotal Platform. The compatibility of other MySQL alternatives with Pivotal Scheduler is not tested or guaranteed.</p>
+<p class="note"><strong>Note:</strong> Pivotal Scheduler is compatible with MySQL for Pivotal Platform; compatibility with MySQL alternatives (e.g. MariaDB) is not tested or guaranteed.</p>
 
 ## <a id="download-install"></a> Download and Install Pivotal Scheduler
 


### PR DESCRIPTION
We do not test with MariaDB. In fact, we know Scheduler does not work
with some versions of MariaDB: 10.0 through 10.4. In particular versions
that use utf8mb4 (or any other multi-byte) character encodings will
fail the initial database migrations.

Don't worry, we are going fix the reference to "MySQL for Pivotal Platform" to "MySQL for VMware Tanzu" in a future commit: [#171059000](https://www.pivotaltracker.com/story/show/171059000)

Co-authored-by: Brian Cunnie <bcunnie@vmware.com>

[#174030015](https://www.pivotaltracker.com/story/show/174030015)