### PR TITLE
Add breaking change documentation for 1.3

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,16 +3,13 @@ title: Scheduler Release Notes
 owner: PCF Autoscaler and Scheduler
 ---
 
-
 This topic contains release notes for Scheduler.
 
-## <a id="1-3-0"></a>v1.3.0
+## <a id='releases'></a> Releases
 
-**Release Date:** ~~May 27, 2020~~
+### <a id="1-3-0"></a>v1.3.0
 
-### Features included in this release
-
-New features and changes in this release:
+**Release Date:** ~~Oct 13, 2020~~
 
 - **Security Fix** Updated dependencies mitigate multiple CVEs
 - **Security Fix** Secrets such as the admin password are scrubbed from the errands
@@ -21,9 +18,39 @@ New features and changes in this release:
 - **Bug Fix** Scheduler CLI Plugin now returns data beyond the first page
 - **Bug Fix** Scheduler no longer incorrectly logs errors caused by jobs that have been deleted
 
-### Known Issues
+This update has a breaking change. Please see [breaking changes](#breaking-changes).
+
+## <a id="known-issues"></a> Known Issues
 
 There are no known issues for this release.
+
+## <a id="breaking-changes"></a> Breaking Changes
+
+Scheduler v1.3.0 includes the following breaking change:
+
+### Internal `database_source.external.url` property is now a secret
+
+This will only affect users of [`om`](https://github.com/pivotal-cf/om) or Pivotal Platform Automation.
+
+If you do not update the product configuration, you will see an error message like the following:
+
+```json
+{"errors":{".properties.database_source.external.url":["cannot assign 'mysql://user:password@example.com:3306' type String, expected Object"]}}
+```
+
+To fix the issue, update your product configuration like this.
+
+```diff
+ product-name: p-scheduler
+ product-properties:
+   .properties.database_source:
+     selected_option: external
+     value: external
+   .properties.database_source.external.url:
+-    value: mysql://user:password@example.com:3306
++    value:
++      secret: mysql://user:password@example.com:3306
+```
 
 ## <a id="view"></a> View Release Notes for Another Version
 


### PR DESCRIPTION
- also refactor headers to be like the TAS tile
- the breaking change was added here:
[#172809240](https://www.pivotaltracker.com/story/show/172809240)

[#173299601](https://www.pivotaltracker.com/story/show/173299601)

Signed-off-by: Brian Cunnie <bcunnie@vmware.com>
Signed-off-by: Andrew Crump <crumpan@vmware.com>