### PR TITLE
Document known issue deleting service keys

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -33,6 +33,11 @@ occurs within a transaction that is not yet visible to the scheduling thread.
 This release bumps the minimum stemcell version from 456.x to 621.90. In addition we now
 specify a minimum patch version for the stemcell.
 
+## <a id="known-issues"></a> Known Issues
+
+- Scheduler v1.4.0 fails when an attempt is made to delete a service key created against
+  a scheduler service instance.
+
 ## <a id="breaking-changes"></a> Breaking Changes in Scheduler v1.4.0
 
 Scheduler v1.4.0 includes the following breaking change:


### PR DESCRIPTION
Scheduler 1.4.0 includes a regression where users are unable to delete service keys created against a scheduler service instance.

Ensure that this is documented in the known issues.

[#175566140](https://www.pivotaltracker.com/story/show/175566140)