### PR TITLE
Update docs to represent changes in upcoming 1.6.0 release of scheduler

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -17,7 +17,7 @@ Scheduler enables developers to do the following:
 
 You can interact with the service through the Cloud Foundry Command Line Interface (cf CLI),
 [Apps Manager](https://docs.pivotal.io/application-service/console/manage-apps.html#enable-scheduling),
-and the [Scheduler HTTP API](https://docs.pivotal.io/scheduler/1-5/api/).
+and the [Scheduler HTTP API](https://docs.pivotal.io/scheduler/1-6/api/).
 
 ## <a id="snapshot"></a>Product Snapshot
 
@@ -28,11 +28,11 @@ The following table provides version and version-support information about Sched
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.5.0</td>
+        <td>v1.6.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>March 15, 2021</td>
+        <td>November 17, 2021</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -7,7 +7,7 @@ This topic describes how to install and configure Scheduler.
 
 ##<a id='prereqs'></a> Prerequisites
 
-Before you install Scheduler v1.5, you must have one of the following:
+Before you install Scheduler v1.6, you must have one of the following:
 
 + A VMware Tanzu SQL with MySQL for VMs v2.7 or later tile. To download VMware Tanzu SQL with MySQL for VMs, see [VMware Tanzu SQL with MySQL for VMs](https://network.pivotal.io/products/pivotal-mysql/) on VMware Tanzu Network. For information about installing VMware Tanzu SQL with MySQL for VMs, see [Installing and Configuring VMware Tanzu SQL with MySQL for VMs](https://docs.pivotal.io/p-mysql/install-config.html). For information about configuring TLS options, see [Configure Security](https://docs.pivotal.io/p-mysql/install-config.html#security).
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,78 +3,24 @@ title: Scheduler Release Notes
 owner: Autoscaler and Scheduler
 ---
 
-This topic contains release notes for Scheduler v1.5.0.
+This topic contains release notes for Scheduler v1.6.0.
 
 ## <a id='releases'></a> Releases
 
-### <a id="1-5-1"></a> v1.5.1
+### <a id="1-6-0"></a> v1.6.0
 
-**Release Date:** July 29, 2021
+**Release Date:** November 17, 2021
 
-- **[Security Fix]** Updated dependencies to mitigate CVE
-- **[Bug Fix]** Addresses an issue where the `scheduler-broker` did not always
-  clean up database references when deprovisioning a service instance
-- **[Bug Fix]** Bump Go to v1.16.6
-- The `scheduler-test` errand now completes faster
+- **[Bug Fix]** Bump Go to 1.17 (see Breaking Changes below)
+- **[Bug Fix]** Bump Spring Boot to 2.5.4
+- **[Bug Fix]** Prevent duplicate jobs from scheduling via new configuration option "Acquire triggers within a lock".
+- **[Bug Fix]** Scheduler no longer fails to deploy on Ops Manager 2.10.19+
 
-
-### <a id="1-5-0"></a> v1.5.0
-
-**Release Date:** March 15, 2021
-
-- **[Security Fix]** Updated dependencies to mitigate CVE
-- **[Bug Fix]** Bump Go to 1.16 (see Breaking Changes below)
-- **[Bug Fix]** Scheduler could exhaust available RAM with a large amount of history. Instead Scheduler now paginates through history.
-- **[Bug Fix]** Service keys can be deleted. In v1.4.0 attempting to delete a service key errored.
-
-## <a id="breaking-changes"></a> Breaking Changes in Scheduler v1.5.0
-
-### <a id="x509-certificates"></a> X.509 Certificates
-
-Scheduler v1.5.0 bumps Go to 1.16. This version of Go changes the treatment of X.509 certificates. This applies to the scheduler-broker
-application and the scheduler cf CLI plugin.
-
-The `CommonName` field on certificates [will not be treated as a hostname](https://golang.org/doc/go1.15#commonname) when no Subject Alternative
-Names are present.
-
-Refer to [the Go 1.16 release notes](https://golang.org/doc/go1.16#crypto/x509) for further details of other changes to treatment of certificates.
-
-#### <a id="tls-termination"></a> TLS Termination
-
-Before upgrading, verify that the system domain for Tanzu Application Service is terminating TLS with a certificate that includes a Subject
-Alternative Name (SAN) for domains under the system domain.
-
-* For example, if your system domain is configured as `sys.example.com`, verify that the certificate presented by `api.sys.example.com`
-  includes a SAN for `api.sys.example.com` or a wildcard `*.sys.example.com`.
-* The `login.sys.example.com` and `scheduler.sys.example.com` endpoints should also present certificates that include a SAN for these subdomains. These can be covered by the same wildcard.
-
-If your configured certificates do not include a SAN for these domains, you must regenerate the certificates. If you attempt to upgrade to
-Scheduler v1.5.0 without regenerating the certificates, you see an error similar to the following in the scheduler service broker logs:
-
-```
-http: panic serving 192.0.2.2:41122: Post "https://login.example.com/check_token": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
-```
-
-This change impacts the Scheduler cf CLI plugin shipped in this release. If the certificates do not include a SAN, the cf CLI produces
-an error similar to the following:
-
-```
-Get "https://scheduler.example.com/jobs?page=1&space_guid=d7759aae-22da-440c-aac8-1bdb0d58ff51": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
-```
-
-For both cases, check that your certificates include SANs for these domains.
-
-#### <a id="database-tls-connections"></a> Database TLS connections
-
-Before upgrading to this release, verify that certificates associated with your MySQL instances that scheduler is configured to use
-include Subject Alternative Names (SANs).
-
-For example, if you configure Scheduler with an external Amazon RDS database, confirm that it is presenting a certificate with a SAN.
-For more information, see [Rotating your SSL/TLS certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html).
+## <a id="breaking-changes"></a> Breaking Changes in Scheduler v1.6.0
 
 ### macOS cf CLI plugin
 
-Scheduler v1.5.0 bumps Go to v1.16. The cf CLI plugin requires macOS 10.12 Sierra or later.
+Scheduler v1.6.0 bumps Go to v1.17. The cf CLI plugin requires macOS 10.13 High Sierra or later.
 
 ## <a id="view"></a> View Release Notes for Another Version
 

--- a/docs-content/upgrade_scheduler.html.md.erb
+++ b/docs-content/upgrade_scheduler.html.md.erb
@@ -1,16 +1,16 @@
 ---
 breadcrumb: PCF Services
-title: Upgrading to Scheduler v1.5
+title: Upgrading to Scheduler v1.6
 ---
 This topic explains how to upgrade Scheduler.
 
 ##<a id="backup"></a>(Optional) Back Up VMware Tanzu SQL with MySQL for VMs Database
 
-VMware recommends backing up your VMware Tanzu SQL with MySQL for VMs database before installing Scheduler v1.5.
+VMware recommends backing up your VMware Tanzu SQL with MySQL for VMs database before installing Scheduler v1.6.
 
 To back up your VMware Tanzu SQL with MySQL for VMs database, see [Manual Backup](https://docs.pivotal.io/p-mysql/backup-restore.html#manual-backup).
 
-##<a id="upgrade-tile"></a>Upgrade Scheduler to v1.5 with all errands enabled.
+##<a id="upgrade-tile"></a>Upgrade Scheduler to v1.6 with all errands enabled.
 
 For general information about upgrading a tile, see [Upgrading Ops Manager Products](https://docs.pivotal.io/ops-manager/install/upgrading-products.html#other-products).
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -77,7 +77,7 @@ TIP: Use 'cf push' to ensure your env variable changes take effect
 
 For information about the CLI operations that you can perform to manage jobs and calls in Scheduler, see [Using Jobs](using-jobs.html) and [Using Calls](using-calls.html).
 
-If you want to manage jobs and calls through the Scheduler HTTP API, see the [Scheduler API Documentation](https://docs.pivotal.io/scheduler/1-5/api/).
+If you want to manage jobs and calls through the Scheduler HTTP API, see the [Scheduler API Documentation](https://docs.pivotal.io/scheduler/1-6/api/).
 
 ## <a id="using-am"></a> Using Scheduler in Apps Manager
 


### PR DESCRIPTION
There's not a `1.6` branch yet, so we're making this PR against `1.5` for the time being, hence all the merge conflicts and crazy high commit number. We created our `1.6` branch off of the `1.5` branch.